### PR TITLE
fix bug

### DIFF
--- a/plugins/zhuquehelper/__init__.py
+++ b/plugins/zhuquehelper/__init__.py
@@ -140,7 +140,6 @@ class ZhuqueHelper(_PluginBase):
             # 获取当前时间戳
             current_time = time.time()
             # 获取最小next_time
-            min_next_time = min((t for t in next_times if t > current_time), default=None)
             min_next_time = min((t for t in next_times if t > current_time), default=current_time)
 
             return bonus, min_level, min_next_time

--- a/plugins/zhuquehelper/__init__.py
+++ b/plugins/zhuquehelper/__init__.py
@@ -141,6 +141,7 @@ class ZhuqueHelper(_PluginBase):
             current_time = time.time()
             # 获取最小next_time
             min_next_time = min((t for t in next_times if t > current_time), default=None)
+            min_next_time = min((t for t in next_times if t > current_time), default=current_time)
 
             return bonus, min_level, min_next_time
 


### PR DESCRIPTION
修复当所有角色技能都可释放时，获取的最小next_time为空，导致角色信息获取失败，从而跳过执行的问题；